### PR TITLE
Document security headers and disable newrelic JS for CSP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,7 @@ ADD who.ini /who.ini
 ADD ckan.ini /ckan.ini
 ADD resource_formats.json /resource_formats.json
 
+ADD newrelic.ini /newrelic.ini
+ENV NEW_RELIC_CONFIG_FILE=/newrelic.ini
+
 CMD ["newrelic-admin", "run-program", "gunicorn", "--workers", "2", "--worker-class", "gevent", "--paste", "ckan.ini", "-t", "600", "--log-file", "-"]

--- a/README.md
+++ b/README.md
@@ -206,6 +206,20 @@ if ($host = www.budgetportal.openup.org.za) {
 if ($host = www.treasurydata.openup.org.za) {
   return 301 $scheme://treasurydata.openup.org.za$request_uri;
 }
+
+## ---
+
+# The X-Frame-Options header indicates whether a browser should be allowed
+# to render a page within a frame or iframe.
+add_header X-Frame-Options SAMEORIGIN;
+
+# MIME type sniffing security protection
+#	There are very few edge cases where you wouldn't want this enabled.
+add_header X-Content-Type-Options nosniff;
+
+# The X-XSS-Protection header is used by Internet Explorer version 8+
+# The header instructs IE to enable its inbuilt anti-cross-site scripting filter.
+add_header X-XSS-Protection "1; mode=block";
 ```
 
 Then let nginx load it

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -1,0 +1,2 @@
+[newrelic]
+browser_monitoring.auto_instrument = false


### PR DESCRIPTION
We will now insert newrelic JS from ckanext-satreasury using the newrelic Copy+Paste method

See also the relevant ckanext-satreasury changes for Content-Security-Policy https://github.com/OpenUpSA/ckanext-satreasury/compare/5b6e297c8bcd06cbf12a1d47c11a718361a3b7f2...openupsa:3c8fb1cf94c24614b91aa831e6afa6da1b57308f